### PR TITLE
issue#14 exclude module types from the back up

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,30 @@ These two scheduled tasks are created and run every 1 minute by default.
 * Create backup adhoc tasks for course migration
 * Create restore adhoc tasks for course migration
 
+## Exclude certain activity types ##
+
+The `excluded_mods` feature allows you to exclude specific activity types from the
+backup on a per-course basis. This is useful when certain modules (e.g. third-party plugins
+like `turnitintooltwo`) should not be included in the migrated
+course backup.
+
+To use this feature, add an optional `excluded_mods` column to your CSV file containing a
+comma-separated list of activity types to exclude. For example:
+
+```
+courseid,categoryid,excluded_mods
+101,5,turnitintooltwo
+102,5,"turnitintooltwo, quiz"
+103,5,
+```
+
+* If the `excluded_mods` column is omitted or left empty for a row, no activity type are excluded
+  and a standard backup is performed.
+* Activity type names must match the plugin's short module name (e.g. `quiz`, `forum`,
+  `turnitintooltwo`), without the `mod_` prefix.
+* An example CSV file with the `excluded_mods` column is available on the
+  `Upload course list` page.
+
 ## Quick start ##
 * Install plugin on source and taget sites.
 * Create a shared folder/disk accessible to both sites in their local file system.
@@ -75,6 +99,7 @@ These two scheduled tasks are created and run every 1 minute by default.
 * Create a web service token _Site administration > Plugins > Web services > Manage tokens_
 * Add the web service token to the source site configuration.
 * Create a CSV file with course id and category id of courses to migrate.
+  * An optional `excluded_mods` column can be added to exclude specific activity types from backup.
   * An example csv file is available on the `Upload course list` page.
 * Upload the csv file at _Site administration > Plugins > Admin tools > Course migration > Upload course list_
 

--- a/classes/coursemigration.php
+++ b/classes/coursemigration.php
@@ -115,6 +115,11 @@ class coursemigration extends persistent {
                 'null' => NULL_ALLOWED,
                 'default' => null,
             ],
+            'excluded_mods' => [
+                'type' => PARAM_TEXT,
+                'null' => NULL_ALLOWED,
+                'default' => null,
+            ],
             'error' => [
                 'type' => PARAM_TEXT,
                 'null' => NULL_ALLOWED,

--- a/classes/output/coursemigration_table.php
+++ b/classes/output/coursemigration_table.php
@@ -62,6 +62,7 @@ class coursemigration_table extends table_sql implements renderable {
             'destinationcategory',
             'status',
             'filename',
+            'excluded_mods',
             'timecreated',
             'timemodified',
             'error',
@@ -74,6 +75,7 @@ class coursemigration_table extends table_sql implements renderable {
             get_string('destinationcategory', 'tool_coursemigration'),
             get_string('status'),
             get_string('filename', 'tool_coursemigration'),
+            get_string('excluded_mods', 'tool_coursemigration'),
             get_string('timecreated', 'tool_coursemigration'),
             get_string('timemodified', 'tool_coursemigration'),
             get_string('error'),
@@ -88,6 +90,7 @@ class coursemigration_table extends table_sql implements renderable {
         $this->no_sorting('destinationcategory');
         $this->no_sorting('status');
         $this->no_sorting('filename');
+        $this->no_sorting('excluded_mods');
         $this->no_sorting('error');
 
         $this->pageable(!empty($pagesize));
@@ -255,6 +258,16 @@ class coursemigration_table extends table_sql implements renderable {
      */
     public function col_filename(stdClass $row): string {
         return $row->filename ?? '';
+    }
+
+    /**
+     * Excluded mods column.
+     *
+     * @param stdClass $row
+     * @return string
+     */
+    public function col_excluded_mods(stdClass $row): string {
+        return $row->excluded_mods ?? '';
     }
 
     /**

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -45,6 +45,7 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
                 'action' => 'privacy:metadata:tool_coursemigration:action',
                 'courseid' => 'privacy:metadata:tool_coursemigration:courseid',
                 'destinationcategoryid' => 'privacy:metadata:tool_coursemigration:destinationcategoryid',
+                'excluded_mods' => 'privacy:metadata:tool_coursemigration:excluded_mods',
                 'usermodified' => 'privacy:metadata:tool_coursemigration:usermodified',
             ],
             'privacy:metadata:tool_coursemigration'
@@ -100,7 +101,7 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
             'tool_coursemigration',
             ['usermodified' => $user->id],
             '',
-            'action,courseid,destinationcategoryid'
+            'action,courseid,destinationcategoryid,excluded_mods'
         );
 
         foreach ($recordset as $record) {
@@ -108,6 +109,7 @@ class provider implements \core_privacy\local\metadata\provider, \core_privacy\l
                 'action' => $record->action,
                 'courseid' => $record->courseid,
                 'destinationcategoryid' => $record->destinationcategoryid,
+                'excluded_mods' => $record->excluded_mods,
             ];
         }
         $recordset->close();

--- a/classes/task/course_backup.php
+++ b/classes/task/course_backup.php
@@ -26,6 +26,7 @@
 namespace tool_coursemigration\task;
 
 use backup;
+use backup_activity_task;
 use backup_controller;
 use backup_plan_dbops;
 use core\task\adhoc_task;
@@ -102,6 +103,21 @@ class course_backup extends adhoc_task {
             // Override setting to not include users.
             $bc->get_plan()->get_setting('users')->set_value(0);
             $bc->get_plan()->get_setting('anonymize')->set_value(0);
+
+            // Apply module exclusions if specified.
+            $excludedmods = $coursemigration->get('excluded_mods');
+            if (!empty($excludedmods)) {
+                $exclusions = array_map('trim', explode(',', $excludedmods));
+                $exclusions = array_map('strtolower', array_filter($exclusions));
+                foreach ($bc->get_plan()->get_tasks() as $task) {
+                    if ($task instanceof backup_activity_task) {
+                        $modulename = strtolower($task->get_modulename());
+                        if (in_array($modulename, $exclusions)) {
+                            $task->get_setting('included')->set_value(0);
+                        }
+                    }
+                }
+            }
 
             $format = $bc->get_format();
             $type = $bc->get_type();

--- a/classes/upload_course_list.php
+++ b/classes/upload_course_list.php
@@ -38,6 +38,13 @@ class upload_course_list {
     ];
 
     /**
+     * Optional columns that may be present in the CSV but are not required.
+     */
+    const OPTIONAL_COLUMNS = [
+        'excluded_mods',
+    ];
+
+    /**
      * Function to process upload courses form.
      *
      * @param csv_import_reader $csvimportreader CSV import reader object.
@@ -141,6 +148,14 @@ class upload_course_list {
             }
         }
 
+        // Handle optional columns.
+        foreach (self::OPTIONAL_COLUMNS as $optcol) {
+            if (isset($fields[$optcol])) {
+                $value = trim($row[$fields[$optcol]['columnindex']]);
+                $data[$optcol] = !empty($value) ? $value : null;
+            }
+        }
+
         return [$status, (object) $data, $message];
     }
 
@@ -182,6 +197,14 @@ class upload_course_list {
         }
 
         $message = empty($errors) ? null : implode(" AND ", $errors);
+
+        // Detect optional columns present in the CSV.
+        foreach (self::OPTIONAL_COLUMNS as $optcol) {
+            if (in_array($optcol, $columns)) {
+                $fields[$optcol] = ['columnname' => $optcol, 'columnindex' => array_search($optcol, $columns)];
+            }
+        }
+
         return [$status, $message, $fields];
     }
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/coursemigration/db" VERSION="20230615" COMMENT="XMLDB file for Moodle admin/tool/coursemigration"
+<XMLDB PATH="admin/tool/coursemigration/db" VERSION="20260805" COMMENT="XMLDB file for Moodle admin/tool/coursemigration"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -12,6 +12,7 @@
         <FIELD NAME="destinationcategoryid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="destination category when restoring"/>
         <FIELD NAME="status" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="0 - failed, 1 - not started, 2 - in progress, 3 - completed"/>
         <FIELD NAME="filename" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="The full Unicode name of this file (case sensitive)"/>
+        <FIELD NAME="excluded_mods" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Comma-separated list of module types to exclude from backup, e.g. turnitintooltwo, quiz"/>
         <FIELD NAME="error" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="in case if the status is failed we need to save an error"/>
         <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -59,5 +59,19 @@ function xmldb_tool_coursemigration_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2023080800, 'tool', 'coursemigration');
     }
 
+    if ($oldversion < 2024112103) {
+        // Define field excluded_mods to be added to tool_coursemigration.
+        $table = new xmldb_table('tool_coursemigration');
+        $field = new xmldb_field('excluded_mods', XMLDB_TYPE_TEXT, null, null, null, null, null, 'filename');
+
+        // Conditionally launch add field excluded_mods.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Coursemigration savepoint reached.
+        upgrade_plugin_savepoint(true, 2024112103, 'tool', 'coursemigration');
+    }
+
     return true;
 }

--- a/example.csv
+++ b/example.csv
@@ -1,4 +1,4 @@
-courseid,categoryid
-1,2
-2,2
-3,4
+courseid,categoryid,excluded_mods
+2,2,
+3,2,"turnitintooltwo, quiz"
+4,4,forum

--- a/lang/en/tool_coursemigration.php
+++ b/lang/en/tool_coursemigration.php
@@ -74,12 +74,15 @@ $string['filters'] = 'Filters';
 $string['from'] = 'From';
 $string['migrationid'] = 'ID';
 $string['missing_column'] = 'CSV file must include one of {$a->columnlist} as column headings';
+$string['excluded_mods'] = 'Excluded activity types';
+$string['excluded_mods_help'] = 'Comma-separated list of activity types to exclude from backup (e.g. turnitintooltwo, quiz).';
 $string['pluginname'] = 'Course migration';
 $string['pluginname_help'] = 'Upload a list of courses as a CSV file that will be migrated to the remote instance as defined in the plugin settings. An example CSV file can be downloaded below.';
 $string['privacy:metadata:tool_coursemigration'] = 'Data relating users for the tool coursemigration plugin';
 $string['privacy:metadata:tool_coursemigration:action'] = 'The action type for course migration';
 $string['privacy:metadata:tool_coursemigration:courseid'] = 'The source/destination courseid';
 $string['privacy:metadata:tool_coursemigration:destinationcategoryid'] = 'The destination categoryid';
+$string['privacy:metadata:tool_coursemigration:excluded_mods'] = 'Comma-separated list of activity types excluded from backup';
 $string['privacy:metadata:tool_coursemigration:usermodified'] = 'The ID of the user who modified the record';
 $string['returnmessages'] = 'File successfully processed.<br\><br\>
 Total rows: {$a->rowcount}<br\>

--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -68,6 +68,7 @@ final class provider_test extends provider_testcase {
         $data->action = coursemigration::ACTION_RESTORE;
         $data->courseid = 123456;
         $data->destinationcategoryid = 654321;
+        $data->excluded_mods = 'turnitintooltwo,quiz';
         $coursemigration1 = new coursemigration(0, $data);
         $coursemigration1->save();
 
@@ -168,6 +169,7 @@ final class provider_test extends provider_testcase {
         $this->assertEquals(coursemigration::ACTION_RESTORE, $coursemigrations['action']);
         $this->assertEquals(123456, $coursemigrations['courseid']);
         $this->assertEquals(654321, $coursemigrations['destinationcategoryid']);
+        $this->assertEquals('turnitintooltwo,quiz', $coursemigrations['excluded_mods']);
 
         writer::reset();
         $writer = writer::with_context($context);
@@ -187,6 +189,7 @@ final class provider_test extends provider_testcase {
         $this->assertEquals(coursemigration::ACTION_BACKUP, $coursemigrations['action']);
         $this->assertEquals(112233, $coursemigrations['courseid']);
         $this->assertEquals(332211, $coursemigrations['destinationcategoryid']);
+        $this->assertNull($coursemigrations['excluded_mods']);
     }
 
     /**

--- a/tests/task/course_backup_test.php
+++ b/tests/task/course_backup_test.php
@@ -44,6 +44,39 @@ require_once($CFG->libdir . '/completionlib.php');
  */
 final class course_backup_test extends advanced_testcase {
     /**
+     * Opens a Moodle backup file (.mbz) and returns the list of activity module
+     * names recorded in moodle_backup.xml.
+     *
+     * @param string $filename Backup filename (as stored in the coursemigration record).
+     * @return string[] Module type names, e.g. ['forum', 'quiz'].
+     */
+    private function get_backup_modulenames(string $filename): array {
+        $directory = get_config('tool_coursemigration', 'directory');
+        $filepath = rtrim($directory, '/') . '/' . $filename;
+
+        $this->assertFileExists($filepath, "Backup file not found at: $filepath");
+
+        $fp = get_file_packer('application/vnd.moodle.backup');
+        $tmpdir = make_backup_temp_directory('test_excluded_mods_' . uniqid());
+        $extracted = $fp->extract_to_pathname($filepath, $tmpdir, ['moodle_backup.xml']);
+        $xmlfile = $tmpdir . '/moodle_backup.xml';
+
+        $this->assertTrue(
+            !empty($extracted) && is_readable($xmlfile),
+            "Could not extract moodle_backup.xml from: $filepath"
+        );
+
+        $xml = simplexml_load_file($xmlfile);
+        remove_dir($tmpdir);
+
+        $modulenames = [];
+        foreach (($xml->information->contents->activities->activity ?? []) as $activity) {
+            $modulenames[] = strtolower((string) $activity->modulename);
+        }
+        return $modulenames;
+    }
+
+    /**
      * Test backup.
      */
     public function test_course_backup() {
@@ -375,6 +408,173 @@ final class course_backup_test extends advanced_testcase {
         $this->assertEquals($coursemigration->get('id'), $event->objectid);
         $this->assertStringContainsString('backup storage has not been configured ', $event->get_description());
         $this->assertEquals(get_string('event:backup_failed', 'tool_coursemigration'), $event->get_name());
+    }
+
+    /**
+     * Test backup with excluded_mods set — backup completes and excluded module is skipped.
+     */
+    public function test_course_backup_with_excluded_mods(): void {
+        global $CFG;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator();
+        $course = $generator->create_course(['fullname' => 'Test module exclusion']);
+
+        // Create a forum and a quiz in the course.
+        $generator->create_module('forum', ['course' => $course->id]);
+        $generator->create_module('quiz', ['course' => $course->id]);
+
+        // Mock restore api.
+        $mockedrestoreapi = $this->createMock(restore_api::class);
+        $mockedrestoreapi->method('request_restore')->willReturn(true);
+        restore_api_factory::set_restore_api($mockedrestoreapi);
+
+        // Create coursemigration record with excluded_mods = 'quiz'.
+        $coursemigration = new coursemigration(0, (object)[
+            'action' => coursemigration::ACTION_BACKUP,
+            'courseid' => $course->id,
+            'destinationcategoryid' => 1,
+            'status' => coursemigration::STATUS_NOT_STARTED,
+            'excluded_mods' => 'quiz',
+        ]);
+        $coursemigration->save();
+
+        // Confirm excluded_mods value.
+        $this->assertEquals('quiz', $coursemigration->get('excluded_mods'));
+
+        // Configure backup directory.
+        set_config('directory', $CFG->tempdir, 'tool_coursemigration');
+
+        $task = new course_backup();
+        $customdata = ['coursemigrationid' => $coursemigration->get('id')];
+        $task->set_custom_data($customdata);
+        manager::queue_adhoc_task($task);
+        ob_start();
+        $task->execute();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Backup completed.', $output);
+
+        // Confirm the status is now completed.
+        $currentcoursemigration = coursemigration::get_record(['id' => $coursemigration->get('id')]);
+        $this->assertEquals(coursemigration::STATUS_COMPLETED, $currentcoursemigration->get('status'));
+        $this->assertNotEmpty($currentcoursemigration->get('filename'));
+        $this->assertStringStartsWith($coursemigration->get('id'), $currentcoursemigration->get('filename'));
+        restore_api_factory::reset_restore_api();
+
+        // Confirm quiz is absent from the backup and forum is present.
+        $modulenames = $this->get_backup_modulenames($currentcoursemigration->get('filename'));
+        $this->assertNotContains('quiz', $modulenames, 'quiz should have been excluded from the backup.');
+        $this->assertContains('forum', $modulenames, 'forum should be present in the backup.');
+    }
+
+    /**
+     * Test backup with excluded_mods containing multiple modules (comma-separated).
+     */
+    public function test_course_backup_with_multiple_excluded_modss(): void {
+        global $CFG;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator();
+        $course = $generator->create_course(['fullname' => 'Test multi-exclusion course']);
+
+        // Create modules in the course.
+        $generator->create_module('forum', ['course' => $course->id]);
+        $generator->create_module('quiz', ['course' => $course->id]);
+
+        // Mock restore api.
+        $mockedrestoreapi = $this->createMock(restore_api::class);
+        $mockedrestoreapi->method('request_restore')->willReturn(true);
+        restore_api_factory::set_restore_api($mockedrestoreapi);
+
+        // Exclude both forum and quiz (space after comma tests trim() handling in task).
+        $coursemigration = new coursemigration(0, (object)[
+            'action' => coursemigration::ACTION_BACKUP,
+            'courseid' => $course->id,
+            'destinationcategoryid' => 1,
+            'status' => coursemigration::STATUS_NOT_STARTED,
+            'excluded_mods' => 'forum, quiz',
+        ]);
+        $coursemigration->save();
+
+        // Confirm excluded_mods value is persisted correctly.
+        $this->assertEquals('forum, quiz', $coursemigration->get('excluded_mods'));
+
+        set_config('directory', $CFG->tempdir, 'tool_coursemigration');
+
+        $task = new course_backup();
+        $task->set_custom_data(['coursemigrationid' => $coursemigration->get('id')]);
+        manager::queue_adhoc_task($task);
+        ob_start();
+        $task->execute();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Backup completed.', $output);
+
+        $currentcoursemigration = coursemigration::get_record(['id' => $coursemigration->get('id')]);
+        $this->assertEquals(coursemigration::STATUS_COMPLETED, $currentcoursemigration->get('status'));
+        $this->assertNotEmpty($currentcoursemigration->get('filename'));
+        restore_api_factory::reset_restore_api();
+
+        // Confirm both forum and quiz are absent from the backup.
+        $modulenames = $this->get_backup_modulenames($currentcoursemigration->get('filename'));
+        $this->assertNotContains('forum', $modulenames, 'forum should have been excluded from the backup.');
+        $this->assertNotContains('quiz', $modulenames, 'quiz should have been excluded from the backup.');
+    }
+
+    /**
+     * Test backup with no excluded_mods — standard backup still works.
+     */
+    public function test_course_backup_without_excluded_mods(): void {
+        global $CFG;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator();
+        $course = $generator->create_course(['fullname' => 'Test no exclusion course']);
+        $generator->create_module('forum', ['course' => $course->id]);
+
+        // Mock restore api.
+        $mockedrestoreapi = $this->createMock(restore_api::class);
+        $mockedrestoreapi->method('request_restore')->willReturn(true);
+        restore_api_factory::set_restore_api($mockedrestoreapi);
+
+        // Create coursemigration record with no excluded_mods.
+        $coursemigration = new coursemigration(0, (object)[
+            'action' => coursemigration::ACTION_BACKUP,
+            'courseid' => $course->id,
+            'destinationcategoryid' => 1,
+            'status' => coursemigration::STATUS_NOT_STARTED,
+        ]);
+        $coursemigration->save();
+
+        // Confirm excluded_mods.
+        $this->assertNull($coursemigration->get('excluded_mods'));
+
+        set_config('directory', $CFG->tempdir, 'tool_coursemigration');
+
+        $task = new course_backup();
+        $task->set_custom_data(['coursemigrationid' => $coursemigration->get('id')]);
+        manager::queue_adhoc_task($task);
+        ob_start();
+        $task->execute();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Backup completed.', $output);
+
+        $currentcoursemigration = coursemigration::get_record(['id' => $coursemigration->get('id')]);
+        $this->assertEquals(coursemigration::STATUS_COMPLETED, $currentcoursemigration->get('status'));
+        $this->assertNotEmpty($currentcoursemigration->get('filename'));
+        restore_api_factory::reset_restore_api();
+
+        // Confirm forum is present in the backup (no exclusions applied).
+        $modulenames = $this->get_backup_modulenames($currentcoursemigration->get('filename'));
+        $this->assertContains('forum', $modulenames, 'forum should be present in the backup when no exclusion is set.');
     }
 
     /**

--- a/tests/upload_course_list_test.php
+++ b/tests/upload_course_list_test.php
@@ -68,6 +68,14 @@ final class upload_course_list_test extends advanced_testcase {
                 'courseid' => $record[0],
                 'destinationcategoryid' => $record[1],
             ]));
+            // Verify excluded_mods value if provided in the test record.
+            if (array_key_exists(2, $record)) {
+                $dbrecord = $DB->get_record('tool_coursemigration', [
+                    'courseid' => $record[0],
+                    'destinationcategoryid' => $record[1],
+                ]);
+                $this->assertEquals($record[2], $dbrecord->excluded_mods);
+            }
         }
 
         $this->assertEquals($expected, $results->get_result_message());
@@ -84,7 +92,7 @@ final class upload_course_list_test extends advanced_testcase {
                     "2,1"],
                 'expected' => "File successfully processed.<br\><br\>\nTotal rows: 1<br\>\nSuccess: 1<br\>\n" .
                     "Failed: 0<br\>\nErrors in CSV file: 0<br\><br\>\n",
-                'dbrecords' => [[2, 1] ],
+                'dbrecords' => [[2, 1, null] ],
             ],
             "One row, valid url and category" => [
                 'input' => ["url,categoryid",
@@ -92,7 +100,7 @@ final class upload_course_list_test extends advanced_testcase {
                 'expected' => "File successfully processed.<br\><br\>\nTotal rows: 1<br\>\nSuccess: 1<br\>\n" .
                     "Failed: 0<br\>\nErrors in CSV file: 0<br\><br\>\n",
 
-                'dbrecords' => [[2, 1] ],
+                'dbrecords' => [[2, 1, null] ],
             ],
             "Four rows, one valid and three errors" => [
                 'input' => ["courseid,categoryid",
@@ -104,7 +112,7 @@ final class upload_course_list_test extends advanced_testcase {
                     "Failed: 3<br\>\nErrors in CSV file: 3<br\><br\>\n" .
                     "Non integer value for courseid found on row 2<br\>Non integer value" .
                     " for categoryid found on row 3<br\>Non integer value for courseid found on row 4",
-                'dbrecords' => [[2, 1] ],
+                'dbrecords' => [[2, 1, null] ],
             ],
             "Invalid columns" => [
                 'input' => ["invalid,invalid",
@@ -112,6 +120,28 @@ final class upload_course_list_test extends advanced_testcase {
                 'expected' => "CSV file must include one of courseid, url as column headings AND CSV file must include one of" .
                     " categoryid as column headings",
                 'dbrecords' => [],
+            ],
+            "One row, with excluded_mods column" => [
+                'input' => ["courseid,categoryid,excluded_mods",
+                    "2,1,\"turnitintooltwo, quiz\""],
+                'expected' => "File successfully processed.<br\><br\>\nTotal rows: 1<br\>\nSuccess: 1<br\>\n" .
+                    "Failed: 0<br\>\nErrors in CSV file: 0<br\><br\>\n",
+                'dbrecords' => [[2, 1, 'turnitintooltwo, quiz']],
+            ],
+            "One row, with empty excluded_mods column" => [
+                'input' => ["courseid,categoryid,excluded_mods",
+                    "2,1,"],
+                'expected' => "File successfully processed.<br\><br\>\nTotal rows: 1<br\>\nSuccess: 1<br\>\n" .
+                    "Failed: 0<br\>\nErrors in CSV file: 0<br\><br\>\n",
+                'dbrecords' => [[2, 1, null]],
+            ],
+            "Multiple rows, some with excluded_mods" => [
+                'input' => ["courseid,categoryid,excluded_mods",
+                    "2,1,quiz",
+                    "3,2,"],
+                'expected' => "File successfully processed.<br\><br\>\nTotal rows: 2<br\>\nSuccess: 2<br\>\n" .
+                    "Failed: 0<br\>\nErrors in CSV file: 0<br\><br\>\n",
+                'dbrecords' => [[2, 1, 'quiz'], [3, 2, null]],
             ],
         ];
     }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_coursemigration';
 $plugin->release = '0.1.0';
-$plugin->version = 2024112102;
+$plugin->version = 2024112103;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [404, 405];


### PR DESCRIPTION
Testing instruction:

- Set up 2 moodle sites
- Set up the tool for migration from a site  ( source) to another (destination)
- Go to 'Upload course list' page on the source site:
https://moodlesiteurl/admin/tool/coursemigration/uploadcourses.php
- Download the example file
- Change the course ids and mod exclusion accordingly.
- Upload the file to the  'Upload course list' 
- Run cron on source site several times so that course backup tasks are created and executed.
- Check if the backup complete successfully:
https://moodlesiteurl/admin/tool/coursemigration/reports.php
- Run cron on destination site several times so that course restore tasks are created and executed.
- Check if the restore complete successfully:
https://moodlesiteurl/admin/tool/coursemigration/reports.php
- Follow the report to check if activities are excluded accordingly.